### PR TITLE
Increased stdout buffer size to 5MB

### DIFF
--- a/index.js
+++ b/index.js
@@ -57,7 +57,7 @@
 
             if(nameRegex !== null && (typeof nameRegex) == 'object' ) regName = nameRegex;
 
-            execFile( "pdftk", [sourceFile, "dump_data_fields_utf8"], function (error, stdout, stderr) {
+            execFile( "pdftk", [sourceFile, "dump_data_fields_utf8"], {"maxBuffer": 1024 * 5000},  function (error, stdout, stderr) {
                 if (error) {
                     console.log('exec error: ' + error);
                     return callback(error, null);


### PR DESCRIPTION
generateFDFTemplate throws maxBuffer size exceeded which results in kill of child process.
This happens when generateFDFTemplate is used for pdf of size as large as 2MB. This is due to maxBuffer size of stdout of child process is Node which is 200KB. 

In this Commit , the maxBuffer size has been increased to 5MB. 